### PR TITLE
Update print stm to python 3 style with parens

### DIFF
--- a/python/lib/genome/coord.py
+++ b/python/lib/genome/coord.py
@@ -585,29 +585,29 @@ if __name__ == "__main__":
 
     coords = [coord1, coord2, coord3, coord4]
 
-    print "NO-STRAND SORTING:"
+    print("NO-STRAND SORTING:")
     sort_coords(coords, use_strand=False)
     for c in coords:
-        print "  " + str(c)
+        print("  " + str(c))
 
-    print "overlaps:"
+    print("overlaps:")
     overlaps = get_overlaps(coords, coords)
     for coord, ov_list in zip(coords, overlaps):
-        print "  " + str(coord) + ":"
+        print("  " + str(coord) + ":")
         for ov in ov_list:
-            print "    " + str(ov)
+            print("    " + str(ov))
 
-    print "STRAND SORTING:"
+    print("STRAND SORTING:")
     sort_coords(coords, use_strand=True)
     for c in coords:
-        print "  " + str(c)
+        print("  " + str(c))
 
-    print "overlaps:"
+    print("overlaps:")
     overlaps = get_overlaps(coords, coords, use_strand=True)
     for coord, ov_list in zip(coords, overlaps):
-        print "  " + str(coord) + ":"
+        print("  " + str(coord) + ":")
         for ov in ov_list:
-            print "    " + str(ov)
+            print("    " + str(ov))
 
 
     # test with a numpy array
@@ -623,21 +623,21 @@ if __name__ == "__main__":
 
     coords2 = coords1.copy()
 
-    print "\nNUMPY ARRAY COORDS:"
-    print "NO-STRAND SORTING"
+    print("\nNUMPY ARRAY COORDS:")
+    print("NO-STRAND SORTING")
     coords1.sort(order=('chromosome_id', 'start'))
     coords2.sort(order=('chromosome_id', 'start'))
     overlaps = get_np_overlaps(coords1, coords2, use_strand=False)
     for i in range(coords1.size):
-        print "%s:\n  %s"  % (str(coords1[i]), str(overlaps[i]))
+        print("%s:\n  %s"  % (str(coords1[i]), str(overlaps[i])))
     
-    print "\nNUMPY ARRAY COORDS:"
-    print "STRAND SORTING"    
+    print("\nNUMPY ARRAY COORDS:")
+    print("STRAND SORTING")
     coords1.sort(order=('chromosome_id', 'strand', 'start'))
     coords2.sort(order=('chromosome_id', 'strand', 'start'))
     overlaps = get_np_overlaps(coords1, coords2, use_strand=True)
     for i in range(coords1.size):
-        print "%s:\n  %s"  % (str(coords1[i]), str(overlaps[i]))
+        print("%s:\n  %s"  % (str(coords1[i]), str(overlaps[i])))
 
 
     

--- a/python/lib/genome/liftover.py
+++ b/python/lib/genome/liftover.py
@@ -66,19 +66,19 @@ if __name__ == "__main__":
 
     # chr1:995669 should convert to chr1:1005806
     new_coord = lifter.convert("chr1", 995669, 1)
-    print new_coord
+    print(new_coord)
 
     # chr1:1007060 should convert to chr1:1017197
     new_coord = lifter.convert("chr1", 1007060, 1)
-    print new_coord
+    print(new_coord)
 
     # chr22:15455353 should convert to chr22:17075353
     new_coord = lifter.convert("chr22", 15455353, 1)
-    print new_coord
+    print(new_coord)
     
     # chr2:1203295 should be deleted in new
     new_coord = lifter.convert("chr2", 1203295, 1)    
-    print new_coord
+    print(new_coord)
     
     
 

--- a/python/lib/genome/quality.py
+++ b/python/lib/genome/quality.py
@@ -20,6 +20,6 @@ if __name__ == "__main__":
     ascii_str = qual_str_to_codes(qual_str)
     new_qual_str = qual_codes_to_str(ascii_str)
     
-    print "original qual str: " + qual_str
-    print "ascii quals str: " + ascii_str
-    print "new qual str: " + new_qual_str
+    print("original qual str: " + qual_str)
+    print("ascii quals str: " + ascii_str)
+    print("new qual str: " + new_qual_str)

--- a/python/lib/genome/transcript.py
+++ b/python/lib/genome/transcript.py
@@ -426,5 +426,5 @@ if __name__ == "__main__":
     trs = read_transcripts(sys.argv[1], chrom_dict)
 
     for tr in trs:
-        print str(tr)
+        print(str(tr))
 

--- a/python/script/db/liftover/chain.py
+++ b/python/script/db/liftover/chain.py
@@ -226,10 +226,10 @@ if __name__ == "__main__":
     chain_list = read_chain_file(liftover_path, gdb18, gdb19)
 
     for c in chain_list:
-        print str(c)
+        print(str(c))
 
         for blk in c.blocks:
-            print "  " + str(blk)
+            print("  " + str(blk))
             
     
         

--- a/python/script/db/list_chromosomes.py
+++ b/python/script/db/list_chromosomes.py
@@ -64,9 +64,9 @@ def main():
 
     for chrom in chromosomes:
         if args.ids:
-            print "%d\t%s\t%d" % (chrom.idnum, chrom.name, chrom.length)
+            print("%d\t%s\t%d" % (chrom.idnum, chrom.name, chrom.length))
         else:
-            print "%s\t%d" % (chrom.name, chrom.length)
+            print("%s\t%d" % (chrom.name, chrom.length))
         
 
 main()

--- a/python/script/db/list_tracks.py
+++ b/python/script/db/list_tracks.py
@@ -23,6 +23,6 @@ tracknames.sort()
 
 for trackname in tracknames:
     if args.paths:
-        print gdb.get_track_path(trackname)
+        print(gdb.get_track_path(trackname))
     else:
-        print trackname
+        print(trackname)

--- a/python/script/parse_ucsc_genes.py
+++ b/python/script/parse_ucsc_genes.py
@@ -31,9 +31,9 @@ def merge_adjacent_exons(exons):
 
 
 def write_header():
-    print "\t".join(["ID", "NAME", "CHROM", "START", "END", "STRAND",
+    print("\t".join(["ID", "NAME", "CHROM", "START", "END", "STRAND",
                      "EXON.STARTS", "EXON.ENDS",
-                     "CDS.START", "CDS.END"])
+                     "CDS.START", "CDS.END"]))
 
 
 def parse_args():
@@ -145,7 +145,7 @@ def main():
         tr = Transcript(name=name, exons=exons,
                         cds_start=cds_start, cds_end=cds_end, idnum=tr_id)
 
-        print str(tr)
+        print(str(tr))
 
     f.close()
 


### PR DESCRIPTION
The library is attempted to be integrated into another script which is
using pytho3.4 and the old style paren-less print calls do not work
since in 3 it is now the print() function
